### PR TITLE
Immich auto update post-stable release

### DIFF
--- a/templates/pods/immich/immich-server.container
+++ b/templates/pods/immich/immich-server.container
@@ -2,7 +2,8 @@
 Pod=immich.pod
 ContainerName=immich_server
 Label=app=immich
-Image=ghcr.io/immich-app/immich-server:v1.143.1
+AutoUpdate=registry
+Image=ghcr.io/immich-app/immich-server:v2
 Environment=DB_HOSTNAME=localhost REDIS_HOSTNAME=localhost
 Secret=immich-db-password,type=env,target=DB_PASSWORD
 # thumbnails and database dumps are also placed here


### PR DESCRIPTION
2.0 is stable and they will follow semver (https://github.com/immich-app/immich/discussions/22546) but ideally I would be tracking a `2.0`/`v2`/etc tag so I'm not one day surprised by 3.0.0 releasing? holding this for now. to be clear the only tags are patch (`v2.0.1`) and the `release` tag